### PR TITLE
Fixed GH Action "command not found" error

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -18,6 +18,7 @@ jobs:
       JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64/
       VERSION: 0.81
       ARCH: armeabi-v7a
+      PATH: ~/.local/bin:${{ env.PATH }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout geniustmusicplayer
@@ -42,7 +43,8 @@ jobs:
       run: make --file python-for-android/ci/makefiles/android.mk
     - name: test P4A
       run: |
-        pip show python-for-android
+        pwd ~
+        ls ~/.local/bin
     - name: Build APK
       env:
         ANDROID_NDK_HOME: /usr/local/lib/android/sdk/android-ndk

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -38,7 +38,12 @@ jobs:
       run: |
         git clone https://github.com/allerter/python-for-android
         pip install -e ./python-for-android
-        echo "{PATH}={~/.local/bin:$PATH}" >> $GITHUB_ENV
+        echo "~/.local/bin" >> $GITHUB_PATH
+    - name: test path
+      run: |
+        echo "$PATH"
+        echo "$GITHUB_PATH"
+        which p4a
     - name: Download Android SDK and NDK
       run: make --file python-for-android/ci/makefiles/android.mk
     - name: Build APK

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -43,9 +43,7 @@ jobs:
     - name: test P4A
       run: |
         pip list
-        echo("-------")
         pip show python-for-android
-        echo("-------")
         which p4a
     - name: Build APK
       env:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -37,12 +37,9 @@ jobs:
     - name: Fork and Install allerter/P4A
       run: |
         git clone https://github.com/allerter/python-for-android
-        pip install -e ./python-for-android
-        echo "~/.local/bin" >> $GITHUB_PATH
+        sudo pip install -e ./python-for-android
     - name: test path
       run: |
-        echo "$PATH"
-        echo "$GITHUB_PATH"
         which p4a
     - name: Download Android SDK and NDK
       run: make --file python-for-android/ci/makefiles/android.mk

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -41,11 +41,6 @@ jobs:
         echo "{PATH}={~/.local/bin:$PATH}" >> $GITHUB_ENV
     - name: Download Android SDK and NDK
       run: make --file python-for-android/ci/makefiles/android.mk
-    - name: test P4A
-      run: |
-        echo "$PATH"
-        pwd ~
-        ls ~/.local/bin
     - name: Build APK
       env:
         ANDROID_NDK_HOME: /usr/local/lib/android/sdk/android-ndk
@@ -90,4 +85,4 @@ jobs:
       env:
         GHR_COMPRESS: zip
         GHR_PATH: geniustmusicplayer/geniustmusicplayer__${{ env.ARCH }}-debug-${{ env.VERSION }}-.apk
-        GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -40,6 +40,13 @@ jobs:
         pip install -e ./python-for-android
     - name: Download Android SDK and NDK
       run: make --file python-for-android/ci/makefiles/android.mk
+    - name: test P4A
+      run: |
+        pip list
+        echo("-------")
+        pip show python-for-android
+        echo("-------")
+        which p4a
     - name: Build APK
       env:
         ANDROID_NDK_HOME: /usr/local/lib/android/sdk/android-ndk

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -43,7 +43,6 @@ jobs:
     - name: test P4A
       run: |
         pip show python-for-android
-        which p4a
     - name: Build APK
       env:
         ANDROID_NDK_HOME: /usr/local/lib/android/sdk/android-ndk

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -42,7 +42,6 @@ jobs:
       run: make --file python-for-android/ci/makefiles/android.mk
     - name: test P4A
       run: |
-        pip list
         pip show python-for-android
         which p4a
     - name: Build APK

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -18,7 +18,6 @@ jobs:
       JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64/
       VERSION: 0.81
       ARCH: armeabi-v7a
-      PATH: ~/.local/bin:${{ env.PATH }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout geniustmusicplayer
@@ -39,10 +38,12 @@ jobs:
       run: |
         git clone https://github.com/allerter/python-for-android
         pip install -e ./python-for-android
+        echo "{PATH}={~/.local/bin:$PATH}" >> $GITHUB_ENV
     - name: Download Android SDK and NDK
       run: make --file python-for-android/ci/makefiles/android.mk
     - name: test P4A
       run: |
+        echo "$PATH"
         pwd ~
         ls ~/.local/bin
     - name: Build APK


### PR DESCRIPTION
- Fixed issue where the `p4a` command was not found, because it needed to be installed with `sudo`.
- Renamed `REPO_GITHUB_TOKEN` TO `GITHUB_TOKEN` to use the default token.